### PR TITLE
feat: Add product cache refresh endpoint to ProductApi

### DIFF
--- a/COMMAND/COMMAND.PRESENTATION/Apis/ProductApi.cs
+++ b/COMMAND/COMMAND.PRESENTATION/Apis/ProductApi.cs
@@ -1,22 +1,30 @@
 ﻿using Carter;
 using COMMAND.CONTRACT.Services.Products;
+using CONTRACT.CONTRACT.CONTRACT.Abstractions.Shared;
 using CONTRACT.CONTRACT.PRESENTATION.Abstractions;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.AspNetCore.Routing;
 
 namespace COMMAND.PRESENTATION.Apis;
 public class ProductApi : ApiEndpoint, ICarterModule
 {
     private const string BaseUrl = "api/v{version:apiVersion}/products";
+    private const string ProductCacheTag = "products";
 
     public void AddRoutes(IEndpointRouteBuilder app)
     {
         var gr1 = app.NewVersionedApi("Products").MapGroup(BaseUrl).HasApiVersion(1);
         gr1.MapPost("", CreateProduct);
         gr1.MapDelete("", DeleteProduct);
+        gr1.MapPost("refresh-cache", RefreshProductCache)
+            .WithName("RefreshProductCache")
+            .Produces(StatusCodes.Status200OK)
+            .WithTags("Products")
+            .WithSummary("Manually invalidate products cache");
     }
 
     private static async Task<IResult> CreateProduct(
@@ -33,5 +41,15 @@ public class ProductApi : ApiEndpoint, ICarterModule
     {
         var result = await sender.Send(command);
         return result.IsFailure ? HandlerFailure(result) : Results.Ok(result);
+    }
+
+    private static async Task<IResult> RefreshProductCache(IOutputCacheStore cacheStore,
+        CancellationToken cancellationToken)
+    {
+        await cacheStore.EvictByTagAsync(ProductCacheTag, cancellationToken);
+        var result = Result.Success("Products cache refreshed successfully");
+        return result.IsFailure
+            ? HandlerFailure(result)
+            : Results.Ok(result);
     }
 }


### PR DESCRIPTION
Add new endpoint `RefreshProductCache` to `ProductApi` for manually invalidating products cache. The endpoint uses `IOutputCacheStore` to evict cache entries tagged with 'products'. This provides a way to force cache refresh when needed without waiting for automatic expiration.

The change includes:
- New constant `ProductCacheTag` for cache management
- New endpoint with OpenAPI metadata (name, tags, summary)
- Result handling consistent with existing API patterns

No breaking changes introduced.