### PR TITLE
refactor: Simplify Result class and remove unused cache functionality

### DIFF
--- a/COMMAND/COMMAND.API/Program.cs
+++ b/COMMAND/COMMAND.API/Program.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.ResponseCompression;
 using Serilog;
 using Serilog.Events;
 using ServiceDefaults;
-using System.IO.Compression;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/COMMAND/COMMAND.PRESENTATION/Apis/ProductApi.cs
+++ b/COMMAND/COMMAND.PRESENTATION/Apis/ProductApi.cs
@@ -8,23 +8,18 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace COMMAND.PRESENTATION.Apis;
 public class ProductApi : ApiEndpoint, ICarterModule
 {
     private const string BaseUrl = "api/v{version:apiVersion}/products";
-    private const string ProductCacheTag = "products";
 
     public void AddRoutes(IEndpointRouteBuilder app)
     {
         var gr1 = app.NewVersionedApi("Products").MapGroup(BaseUrl).HasApiVersion(1);
         gr1.MapPost("", CreateProduct);
         gr1.MapDelete("", DeleteProduct);
-        gr1.MapPost("refresh-cache", RefreshProductCache)
-            .WithName("RefreshProductCache")
-            .Produces(StatusCodes.Status200OK)
-            .WithTags("Products")
-            .WithSummary("Manually invalidate products cache");
     }
 
     private static async Task<IResult> CreateProduct(
@@ -41,15 +36,5 @@ public class ProductApi : ApiEndpoint, ICarterModule
     {
         var result = await sender.Send(command);
         return result.IsFailure ? HandlerFailure(result) : Results.Ok(result);
-    }
-
-    private static async Task<IResult> RefreshProductCache(IOutputCacheStore cacheStore,
-        CancellationToken cancellationToken)
-    {
-        await cacheStore.EvictByTagAsync(ProductCacheTag, cancellationToken);
-        var result = Result.Success("Products cache refreshed successfully");
-        return result.IsFailure
-            ? HandlerFailure(result)
-            : Results.Ok(result);
     }
 }

--- a/CONTRACT/CONTRACT/CONTRACT.CONTRACT/Abstractions/Shared/Result.cs
+++ b/CONTRACT/CONTRACT/CONTRACT.CONTRACT/Abstractions/Shared/Result.cs
@@ -1,10 +1,10 @@
 namespace CONTRACT.CONTRACT.CONTRACT.Abstractions.Shared;
 public class Result
 {
-    protected internal Result(bool isSuccess, Error error)
+    protected Result(bool isSuccess, Error error)
     {
-        if (isSuccess && error != Error.None) throw new InvalidOperationException();
-        if (!isSuccess && error == Error.None) throw new InvalidOperationException();
+        if (isSuccess && error != Error.None || !isSuccess && error == Error.None)
+            throw new InvalidOperationException();
 
         IsSuccess = isSuccess;
         Error = error;


### PR DESCRIPTION
- Change `Result` constructor access modifier from `protected internal` to `protected` in `CONTRACT.CONTRACT/Abstractions/Shared/Result.cs` and combine validation conditions
- Remove unused `System.IO.Compression` namespace from `COMMAND.API/Program.cs`
- Remove product cache refresh endpoint and related code from `ProductApi` in `COMMAND.PRESENTATION/Apis/ProductApi.cs` as it's no longer needed
- Clean up unused `ProductCacheTag` constant and cache-related dependencies